### PR TITLE
exclude empty groups from enemy array for compatibility with groupless helper units

### DIFF
--- a/FUPS/functions/misc/fn_mainHandlerOverhead.sqf
+++ b/FUPS/functions/misc/fn_mainHandlerOverhead.sqf
@@ -48,9 +48,9 @@ if (count FUPS_oefGroups_toDelete > 0) then {
 {
 	private _side = side _x;
 	// refill the enemie arrays
-	if (west getFriend _side < 0.6) then {FUPS_enemies_west pushBack _x};
-	if (east getFriend _side < 0.6) then {FUPS_enemies_east pushBack _x};
-	if (independent getFriend _side < 0.6) then {FUPS_enemies_guer pushBack _x};
+	if (west getFriend _side < 0.6 && count units _x > 0) then {FUPS_enemies_west pushBack _x};
+	if (east getFriend _side < 0.6 && count units _x > 0) then {FUPS_enemies_east pushBack _x};
+	if (independent getFriend _side < 0.6 && count units _x > 0) then {FUPS_enemies_guer pushBack _x};
 } forEach allGroups;
 
 if (count FUPS_oefGroups_toAdd > 0) then {


### PR DESCRIPTION
ATLAS LHD Mod uses helper object which spams

`21:18:37 "FUPS_log in FUPS_fnc_mainHandler: B Alpha 1-1, Error: group O Charlie 4-1 is null or empty - looping enemies"`

Fixed this for me with excluding empty groups from enemies-array. Dont know if this has any other implications.